### PR TITLE
Improve ACM LaTeX manuscript formatting

### DIFF
--- a/sample-manuscript.tex
+++ b/sample-manuscript.tex
@@ -150,30 +150,30 @@
 <ccs2012>
   <concept>
     <concept_id>10010405.10010469.10010470</concept_id>
-    <concept_desc>Ingeniería de alimentos~Ciencia y tecnología de alimentos</concept_desc>
+    <concept_desc>Ingenier\'{i}a de alimentos~Ciencia y tecnolog\'{i}a de alimentos</concept_desc>
     <concept_significance>500</concept_significance>
   </concept>
   <concept>
     <concept_id>10010147.10010341.10010349.10010350</concept_id>
-    <concept_desc>Matemáticas aplicadas~Diseño experimental</concept_desc>
+    <concept_desc>Matem\'aticas aplicadas~Dise\~{n}o experimental</concept_desc>
     <concept_significance>300</concept_significance>
   </concept>
   <concept>
     <concept_id>10010405.10010444.10010449</concept_id>
-    <concept_desc>Ingeniería de alimentos~Productos de confitería</concept_desc>
+    <concept_desc>Ingenier\'{i}a de alimentos~Productos de confiter\'ia</concept_desc>
     <concept_significance>100</concept_significance>
   </concept>
 </ccs2012>
 \end{CCSXML}
 
-\ccsdesc[500]{Ingeniería de alimentos~Ciencia y tecnología de alimentos}
-\ccsdesc[300]{Matemáticas aplicadas~Diseño experimental}
-\ccsdesc[100]{Ingeniería de alimentos~Productos de confitería}
+\ccsdesc[500]{Ingenier\'{i}a de alimentos~Ciencia y tecnolog\'{i}a de alimentos}
+\ccsdesc[300]{Matem\'aticas aplicadas~Dise\~{n}o experimental}
+\ccsdesc[100]{Ingenier\'{i}a de alimentos~Productos de confiter\'ia}
 
 %-------------------------------------------------------
 % Palabras clave (versión en español)
 %-------------------------------------------------------
-\keywords{chocotejas, beterraga, quinua pop, kiwicha pop, análisis sensorial, textura, humedad, densidad, actividad de agua}
+\keywords{chocotejas, beterraga, quinua pop, kiwicha pop, an\'alisis sensorial, textura, humedad, densidad, actividad de agua}
 
 %%-------------------------------------------------------
 %% Fechas de procesamiento del manuscrito (en español)
@@ -205,8 +205,8 @@
           \begin{minipage}{0.48\linewidth}
             \centering
             \includegraphics[width=0.9\linewidth]{imagen/beterraga-quinua.jpeg}
+            \Description{Relleno de beterraga rallada con quinua pop en moldes}
             
-            \vspace{1mm}
             
             \small (a) Relleno de beterraga rallada dispuesto en moldes de chocotejas. Se observa la mezcla de quinua pop en la parte inferior.
           \end{minipage}
@@ -214,8 +214,8 @@
           \begin{minipage}{0.48\linewidth}
             \centering
             \includegraphics[width=0.9\linewidth]{imagen/coc-beterraga.jpeg}
+            \Description{Cocción de beterraga entera en agua}
             
-            \vspace{1mm}
             
             \small (b) Cocción de beterraga entera en agua hirviendo durante los tratamientos térmicos.
           \end{minipage}
@@ -225,8 +225,8 @@
           \begin{minipage}{0.48\linewidth}
             \centering
             \includegraphics[width=0.9\linewidth]{imagen/kiwicha.jpeg}
+            \Description{Pesaje de quinua pop en balanza}
             
-            \vspace{1mm}
             
             \small (c) Pesaje de quinua pop en balanza digital (165.25 g).
           \end{minipage}
@@ -234,8 +234,8 @@
           \begin{minipage}{0.48\linewidth}
             \centering
             \includegraphics[width=0.9\linewidth]{imagen/rallado.jpeg}
+            \Description{Rallado manual de beterraga cocida}
             
-            \vspace{1mm}
             
             \small (d) Rallado manual de beterraga cocida previo al mezclado con pseudocereales.
           \end{minipage}
@@ -245,12 +245,12 @@
         \end{figure}
 
            
-    \subsection{Diseño experimental}
+    \subsection{Disen~{n}o experimental}
     Se adoptó un diseño completamente al azar con tres tratamientos definidos por el tiempo de cocción de la beterraga:  
     T\textsubscript{0} (0 min, cruda),  
     T\textsubscript{1} (20 min) y  
     T\textsubscript{2} (40 min).  
-    Cada tratamiento se elaboró en un lote de 24 chocotejas; mediante muestreo aleatorio se seleccionaron cuatro unidades por lote para los análisis fisicoquímicos y sensoriales.
+    Cada tratamiento se elaboró en un lote de 24 chocotejas; mediante muestreo aleatorio se seleccionaron cuatro unidades por lote para los an\'alisis fisicoquímicos y sensoriales.
     
     \subsection{Procedimiento de elaboración}
     \paragraph{Cobertura.} El chocolate se fundió a 45\,°C, se atemperó a 27\,°C y finalmente se estabilizó a 31\,°C antes de mezclarse con kiwicha \emph{pop}.  
@@ -412,7 +412,7 @@ De igual modo, la actividad de agua ($a_w$) mostró un descenso progresivo de 0.
 
 \subsection{Evaluación sensorial}
 
-El análisis sensorial (Tabla~\ref{tab:sensorial}) mostró que el tratamiento de 20 minutos (T\textsubscript{1}) obtuvo puntuaciones significativamente superiores ($p < 0.05$) en todos los atributos evaluados, alcanzando una aceptabilidad global de 8.1 $\pm$ 0.4 puntos. Los jueces describieron la textura como “muy crujiente” y el sabor equilibrado entre chocolate y beterraga. El exceso de humedad en T\textsubscript{0} disminuyó la crocancia, mientras que T\textsubscript{2} (40 min) presentó notas terrosas atribuidas a la degradación de pigmentos y formación de compuestos secundarios \cite{Montoya2011}.
+El an\'alisis sensorial (Tabla~\ref{tab:sensorial}) mostró que el tratamiento de 20 minutos (T\textsubscript{1}) obtuvo puntuaciones significativamente superiores ($p < 0.05$) en todos los atributos evaluados, alcanzando una aceptabilidad global de 8.1 $\pm$ 0.4 puntos. Los jueces describieron la textura como “muy crujiente” y el sabor equilibrado entre chocolate y beterraga. El exceso de humedad en T\textsubscript{0} disminuyó la crocancia, mientras que T\textsubscript{2} (40 min) presentó notas terrosas atribuidas a la degradación de pigmentos y formación de compuestos secundarios \cite{Montoya2011}.
 
 \begin{table}[H]
   \centering
@@ -441,14 +441,14 @@ El análisis sensorial (Tabla~\ref{tab:sensorial}) mostró que el tratamiento de
   \begin{minipage}{0.3\linewidth}
     \centering
     \includegraphics[width=\linewidth]{imagen/densidad 1.jpeg}
-    \vspace{1mm}
+    \Description{Pesaje individual de chocoteja}
     \small (a) Pesaje de la chocoteja individual en balanza analítica (16.27 g).
   \end{minipage}
   \hspace{1em}
   \begin{minipage}{0.2\linewidth}
     \centering
     \includegraphics[width=\linewidth]{imagen/densidad.jpeg}
-    \vspace{1mm}
+    \Description{Medición de volumen en probeta}
     \small (b) Medición de volumen desplazado en probeta para cálculo de densidad.
   \end{minipage}
 
@@ -457,14 +457,14 @@ El análisis sensorial (Tabla~\ref{tab:sensorial}) mostró que el tratamiento de
   \begin{minipage}{0.3\linewidth}
     \centering
     \includegraphics[width=\linewidth]{imagen/Humedad.jpeg}
-    \vspace{1mm}
+    \Description{Determinación instrumental de humedad}
     \small (c) Determinación de humedad en balanza termogravimétrica.
   \end{minipage}
   \hspace{1em}
   \begin{minipage}{0.2\linewidth}
     \centering
     \includegraphics[width=\linewidth]{imagen/pH.jpeg}
-    \vspace{1mm}
+    \Description{Evaluación de pH con tiras indicadoras}
     \small (d) Evaluación de pH mediante papel indicador.
   \end{minipage}
 
@@ -473,11 +473,11 @@ El análisis sensorial (Tabla~\ref{tab:sensorial}) mostró que el tratamiento de
   \begin{minipage}{0.2\linewidth}
     \centering
     \includegraphics[width=\linewidth]{imagen/resultado 1.jpeg}
-    \vspace{1mm}
+    \Description{Chocotejas terminadas en bandeja}
     \small (e) Chocotejas terminadas dispuestas en bandejas de moldeo.
   \end{minipage}
 
-  \caption{Etapas del proceso de análisis fisicoquímico y producción de chocotejas funcionales: determinación de densidad, humedad, pH y presentación final del producto.}
+  \caption{Etapas del proceso de an\'alisis fisicoquímico y producción de chocotejas funcionales: determinación de densidad, humedad, pH y presentación final del producto.}
   \label{fig:proceso_analisis}
 \end{figure}
 


### PR DESCRIPTION
## Summary
- fix accents in CCS concepts and keywords
- add alt text with `\Description` to figures
- remove extra vertical space and provide figure descriptions

## Testing
- `pdflatex sample-manuscript.tex`
- `bibtex sample-manuscript`
- `pdflatex sample-manuscript.tex` (twice)


------
https://chatgpt.com/codex/tasks/task_e_686becdd4dfc8320b4bab16831d49404